### PR TITLE
chore: Ignore Cloud Functions build output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ node_modules/
 
 # dataconnect generated files
 .dataconnect
+
+# Functions build output directory
+lib

--- a/firebase/.gitignore
+++ b/firebase/.gitignore
@@ -67,3 +67,6 @@ node_modules/
 
 # dataconnect generated files
 .dataconnect
+
+# Functions build output directory
+lib


### PR DESCRIPTION
This pull request updates the `.gitignore` file to exclude the Cloud Functions build output directory (lib).

When deploying or building Firebase/Cloud Functions, the TypeScript source files are transpiled into JavaScript and stored in the lib folder. These are generated artifacts and should not be tracked in version control, as they can be rebuilt from the source code.